### PR TITLE
Fixed build error with newer versions of gradle

### DIFF
--- a/giraffeplayer2/src/main/res/values/ids.xml
+++ b/giraffeplayer2/src/main/res/values/ids.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <item name="player_display" type="id">player_display</item>
-    <item name="player_display_box" type="id">player_display_box</item>
-    <item name="player_display_float_box" type="id">player_display_float_box</item>
+    <item name="player_display" type="id"/>
+    <item name="player_display_box" type="id"/>
+    <item name="player_display_float_box" type="id"/>
 </resources>


### PR DESCRIPTION
ID tags that are not blank cause merging errors in newer versions of gradle build tools. Unless these values are removed this code will not build for newer projects.

ref: https://stackoverflow.com/questions/52076491/android-inner-element-must-either-be-a-resource-reference-or-empty